### PR TITLE
Fix body handling and optional aiohttp dependency

### DIFF
--- a/asyncurlify.py
+++ b/asyncurlify.py
@@ -1,10 +1,13 @@
-import aiohttp
 import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from aiohttp import ClientResponse
 
 from shlex import quote
 
 
-def to_curl(request: aiohttp.ClientResponse, body=None, compressed=False, verify=True):
+def to_curl(request: 'ClientResponse', body=None, compressed=False, verify=True):
 
     parts = [
         ("curl", None),
@@ -14,10 +17,10 @@ def to_curl(request: aiohttp.ClientResponse, body=None, compressed=False, verify
     for k, v in sorted(request.request_info.headers.items()):
         parts += [("-H", "{0}: {1}".format(k, v))]
 
-    if body:
+    if body is not None:
         if isinstance(body, dict):
-            body = json.dumps(body).encode("utf-8")
-        if isinstance(body, bytes):
+            body = json.dumps(body)
+        elif isinstance(body, bytes):
             body = body.decode("utf-8")
         parts += [("-d", body)]
 
@@ -31,8 +34,8 @@ def to_curl(request: aiohttp.ClientResponse, body=None, compressed=False, verify
 
     flat_parts = []
     for k, v in parts:
-        if k:
+        if k is not None:
             flat_parts.append(quote(k))
-        if v:
+        if v is not None:
             flat_parts.append(quote(v))
     return " ".join(flat_parts)

--- a/tests/test_asyncurlify.py
+++ b/tests/test_asyncurlify.py
@@ -1,0 +1,21 @@
+import unittest
+from asyncurlify import to_curl
+
+class DummyRequestInfo:
+    def __init__(self, method='GET', url='http://example.com', headers=None):
+        self.method = method
+        self.url = url
+        self.headers = headers or {}
+
+class DummyResponse:
+    def __init__(self, method='GET', url='http://example.com', headers=None):
+        self.request_info = DummyRequestInfo(method, url, headers)
+
+class CurlifyTests(unittest.TestCase):
+    def test_empty_body_included(self):
+        resp = DummyResponse(headers={'User-Agent': 'test'})
+        curl_cmd = to_curl(resp, body='')
+        self.assertIn("-d ''", curl_cmd)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid requiring `aiohttp` at import time
- ensure empty bodies get included in generated cURL commands
- add a unit test for empty body handling

## Testing
- `python -m unittest tests/test_asyncurlify.py`
- `python -m py_compile asyncurlify.py tests/test_asyncurlify.py`