### PR TITLE
Fix to_curl body decoding

### DIFF
--- a/asyncurlify.py
+++ b/asyncurlify.py
@@ -18,7 +18,8 @@ def to_curl(request: aiohttp.ClientResponse, body=None, compressed=False, verify
         if isinstance(body, dict):
             body = json.dumps(body).encode("utf-8")
         if isinstance(body, bytes):
-            body = body.decode("utf-8")
+            # fall back to replacing invalid bytes when decoding
+            body = body.decode("utf-8", errors="replace")
         parts += [("-d", body)]
 
     if compressed:


### PR DESCRIPTION
## Summary
- handle invalid UTF-8 bytes when decoding the body in `to_curl`
- add a short comment explaining fallback decoding

## Testing
- `python -m py_compile asyncurlify.py`