### PR TITLE
Fix header formatting line

### DIFF
--- a/asyncurlify.py
+++ b/asyncurlify.py
@@ -33,7 +33,7 @@ def to_curl(request: 'ClientResponse', body=None, compressed=False, verify=True)
     ]
 
     for k, v in sorted(request.request_info.headers.items()):
-        parts += [("-H", "{0}: {1}".format(k, v))]
+        parts.append(("-H", f"{k}: {v}"))
 
     if body is not None:
         if isinstance(body, dict):


### PR DESCRIPTION
## Summary
- improve request header formatting by appending tuples directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c079590ac832bb5b5f310fb45b9aa