### PR TITLE
Add __all__ entry for to_curl

### DIFF
--- a/asyncurlify.py
+++ b/asyncurlify.py
@@ -6,6 +6,8 @@ if TYPE_CHECKING:
 
 from shlex import quote
 
+__all__ = ["to_curl"]
+
 
 def to_curl(request: 'ClientResponse', body=None, compressed=False, verify=True):
     """Return a cURL command for the given request.


### PR DESCRIPTION
## Summary
- expose `to_curl` as a public API by defining `__all__` in `asyncurlify.py`

## Testing
- `pytest -q`